### PR TITLE
add readme badges

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -3,5 +3,10 @@
     "lint": {
       "engine": "none"
     }
+  },
+  "dependencies": {
+    "mute": [
+      "jest"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,8 @@
+[![bitHound Overall Score](https://www.bithound.io/projects/badges/2258aae0-8f63-11e7-b68c-bd8234fdabb6/score.svg)](https://www.bithound.io/github/KualiCo/kuali-logger)
+[![bitHound Dependencies](https://www.bithound.io/projects/badges/2258aae0-8f63-11e7-b68c-bd8234fdabb6/dependencies.svg)](https://www.bithound.io/github/KualiCo/kuali-logger/master/dependencies/npm)
+[![codecov](https://codecov.io/gh/KualiCo/kuali-logger/branch/master/graph/badge.svg?token=OMwRfQrCqY)](https://codecov.io/gh/KualiCo/kuali-logger)
+[![CircleCI](https://circleci.com/gh/KualiCo/kuali-logger/tree/master.svg?style=shield&circle-token=b8b3696e50f3bce018f444658e7bd9c738d41751)](https://circleci.com/gh/KualiCo/kuali-logger/tree/master)
+
 # Kuali Logger
 
 Standardized logger for Kuali applications. The logger simplifies the process of making log output follow the Kuali Logging Standards.


### PR DESCRIPTION
Also muting bit hound jest dependency errors. It has a valid BSD 3-clause license, but bit hound doesn't think so for some reason.