### PR TITLE
Add back tenant info

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -51,7 +51,9 @@ function getMiddlewareConfig (config, logger) {
     excludeHeaders: config.excludeHeaders || [],
     additionalRequestFinishData: req => {
       const extraFields = {
-        event: 'REQUEST'
+        event: 'REQUEST',
+        tenant: req.headers['x-kuali-tenant'],
+        lane: req.headers['x-kuali-lane']
       }
       return extraFields
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuali-logger",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Standardized logger for Kuali apps",
   "main": "lib/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ log.info({ event: 'COURSE_CREATE' }, 'New course create')
   "hostname": "230ff563d429",
   "pid": 71132,
   "level": "INFO",
-  "event": "COURSE_CREATED",
+  "event": "COURSE_CREATE",
   "msg": "New course created",
   "time": "2017-09-04T19:04:26.481Z",
   "v": 0
@@ -150,7 +150,7 @@ The event parameter is a string used to log events with a unique, searchable id.
 * `LOGIN_FAILURE`
 * `COURSE_CREATE`
 * `PROTOCOL_READ`
-* `REPORT_CREATE`
+* `REPORT_DELETE`
 * `NOTIFICATION_SEND_SUCCESS`
 * `ERROR`
 * `REQUEST`

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -63,6 +63,8 @@ describe('middleware', () => {
         .end((err, res) => {
           if (err) throw err
           expect(catcher.last.event).toBe('REQUEST')
+          expect(catcher.last.tenant).toBe('tenant')
+          expect(catcher.last.lane).toBe('lane')
           done()
         })
     })


### PR DESCRIPTION
For potential consistency with non-request log entries, adding tenant and info back to the root log entry.